### PR TITLE
fixing buggy shadowRoot code

### DIFF
--- a/src/shadowDOM.js
+++ b/src/shadowDOM.js
@@ -2,7 +2,7 @@
         Platform.nativeShadowDOM = true;
         logFlags.dom && console.log('Native Shadow DOM detected');
 
-        var originalCreateShadowRoot = Element.prototype.webkitCreateShadowRoot;
+        var originalCreateShadowRoot = HTMLElement.prototype.webkitCreateShadowRoot || HTMLElement.prototype.createShadowRoot;
         Element.prototype.webkitCreateShadowRoot = function() {
             var elderRoot = this.webkitShadowRoot;
             var root = originalCreateShadowRoot.call(this);


### PR DESCRIPTION
this code raises an Uncaught TypeError: Cannot read property 'call' of undefined in current versions of Chrome. 

Fixing so the logic makes more sense (and doesn't cause errors).
